### PR TITLE
Set Ruby 2.7 as minimal version

### DIFF
--- a/foreman_hdm.gemspec
+++ b/foreman_hdm.gemspec
@@ -14,6 +14,8 @@ Gem::Specification.new do |s|
   s.files = Dir['{app,config,db,lib,locale,webpack}/**/*'] + ['LICENSE', 'Rakefile', 'README.md', 'package.json']
   s.test_files = Dir['test/**/*'] + Dir['webpack/**/__tests__/*.js']
 
+  s.required_ruby_version = Gem::Requirement.new('>= 2.7')
+
   s.add_development_dependency 'rubocop'
   s.add_development_dependency 'rdoc'
 end


### PR DESCRIPTION
```
10:39:09   bastelfreak | Zhenech: what's the lowest ruby version the plugins need to support?
10:50:54       Zhenech | bastelfreak, =2.7
```