### PR TITLE
GitHub Action: Grant write access to packages API

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   release:
+    permissions:
+      packages: write
     runs-on: ubuntu-latest
     if: github.repository_owner == 'betadots'
     steps:


### PR DESCRIPTION
by default, the GitHub Actions only get a token that's read-only. We need write access to publish the gem.