### PR TITLE
package.json: Apply versions from foreman_ansible

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "http://projects.theforeman.org/projects/foreman_hdm/issues"
   },
   "peerDependencies": {
-    "@theforeman/vendor": ">= 6.0.0"
+    "@theforeman/vendor": ">= 12.0.1"
   },
   "dependencies": {
     "react-intl": "^2.8.0"
@@ -29,12 +29,11 @@
   "devDependencies": {
     "@babel/core": "^7.7.0",
     "@sheerun/mutationobserver-shim": "^0.3.3",
-    "@theforeman/builder": "^6.0.0",
-    "@theforeman/eslint-plugin-foreman": "6.0.0",
-    "@theforeman/find-foreman": "^4.8.0",
-    "@theforeman/stories": "^7.0.0",
-    "@theforeman/test": "^8.0.0",
-    "@theforeman/vendor-dev": "^6.0.0",
+    "@theforeman/builder": ">= 12.0.1",
+    "@theforeman/eslint-plugin-foreman": ">= 12.0.1",
+    "@theforeman/find-foreman": ">= 12.0.1",
+    "@theforeman/test": ">= 12.0.1",
+    "@theforeman/vendor-dev": ">= 12.0.1",
     "babel-eslint": "^10.0.3",
     "eslint": "^6.7.2",
     "prettier": "^1.19.1",


### PR DESCRIPTION
We noticed that initial builds for the plugin didn't pass: https://ci.theforeman.org/blue/organizations/jenkins/foreman-packaging-rpm-pr-test/detail/foreman-packaging-rpm-pr-test/10696/pipeline/

Zhenech suggested to adjust the dependencies like in https://github.com/theforeman/foreman_ansible/commit/4fabaf9db9296c0dfcd84b575031018968d5ff2a