### PR TITLE
Clarifiy license: GPL-3.0->GPL-3.0-only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,10 @@ jobs:
     if: github.repository_owner == 'betadots'
     steps:
       - uses: actions/checkout@v4
-      - name: Install Ruby 3.0
+      - name: Install Ruby 3.3
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.0'
+          ruby-version: '3.3'
         env:
           BUNDLE_WITHOUT: release:development:rubocop
       - name: Build gem

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install Ruby ${{ matrix.ruby }}
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.2"
+          ruby-version: "3.3"
           bundler-cache: true
       - name: Run Rubocop
         run: bundle exec rake rubocop
@@ -32,6 +32,7 @@ jobs:
           - "3.0"
           - "3.1"
           - "3.2"
+          - "3.3"
     name: Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v4

--- a/foreman_hdm.gemspec
+++ b/foreman_hdm.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |s|
   s.name        = 'foreman_hdm'
   s.version     = ForemanHdm::VERSION
   s.metadata    = { 'is_foreman_plugin' => 'true' }
-  s.license     = 'GPL-3.0'
+  s.license     = 'GPL-3.0-only'
   s.authors     = ['betadots GmbH']
   s.email       = ['info@betadots.de']
   s.homepage    = 'https://github.com/betadots/foreman_hdm'


### PR DESCRIPTION
Ruby 3.3 introduces a stricter license string validation and GPL-3.0 is deprecated.

Also contains #29 